### PR TITLE
Fix List/Tree foreground color of the match highlights

### DIFF
--- a/theme/macOS-classic.json
+++ b/theme/macOS-classic.json
@@ -53,6 +53,7 @@
     "list.activeSelectionForeground": "#ffffff",
     "list.inactiveSelectionBackground": "#B9B9B9",
     "list.inactiveSelectionForeground": "#262426",
+    "list.focusHighlightForeground": "#9dddff",
     "titleBar.activeBackground": "#c4c4c4",
     "titleBar.border": "#c4c4c4",
     "notification.background": "#54a3ff",


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/28998859/173871679-50f8914a-9904-4f4f-acad-5463f93467a5.png)

After:
![image](https://user-images.githubusercontent.com/28998859/173871750-ead16f7a-785c-4000-b2e4-d00e6c134351.png)
