### PR TITLE
Add coloring for placeholder and escape token

### DIFF
--- a/theme/macOS-classic-dark.json
+++ b/theme/macOS-classic-dark.json
@@ -167,6 +167,18 @@
       }
     },
     {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#e3f2b6"
+      }
+    },
+    {
+      "scope": "constant.other.placeholder",
+      "settings": {
+        "foreground": "#e3f2b6"
+      }
+    },
+    {
       "scope": [
         "variable.other.constant",
         "variable.other.class",

--- a/theme/macOS-classic-dark2.json
+++ b/theme/macOS-classic-dark2.json
@@ -167,6 +167,18 @@
       }
     },
     {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#b8b8b8"
+      }
+    },
+    {
+      "scope": "constant.other.placeholder",
+      "settings": {
+        "foreground": "#449cd3"
+      }
+    },
+    {
       "scope": [
         "variable.other.constant",
         "variable.other.class",

--- a/theme/macOS-classic.json
+++ b/theme/macOS-classic.json
@@ -166,6 +166,18 @@
       }
     },
     {
+      "scope": "constant.character.escape",
+      "settings": {
+        "foreground": "#30BA30"
+      }
+    },
+    {
+      "scope": "constant.other.placeholder",
+      "settings": {
+        "foreground": "#cd3131"
+      }
+    },
+    {
       "scope": [
         "variable.other.constant",
         "variable.other.class",


### PR DESCRIPTION
This PR asks to add differenciated coloring to placeholders and escape tokens in (formatted) strings.

## screenshots
(all examples are from golang)
### old behaviour
![Bildschirmfoto 2024-08-13 um 11 06 23](https://github.com/user-attachments/assets/a4f5ad31-c8cd-48fe-9c2d-0e21d6ad9c6e)

### targeted behaviour (screenshot took from TextMate window within the same file)
<img width="223" alt="Bildschirmfoto 2024-08-13 um 11 06 34" src="https://github.com/user-attachments/assets/ff9e6400-e15f-4486-bf6f-70d756b6bc2e">

### new behaviour
#### light theme
![Bildschirmfoto 2024-08-13 um 11 47 23](https://github.com/user-attachments/assets/1acb4d53-f430-4f4d-aa07-e8919886c6ba)

#### dark theme
![Bildschirmfoto 2024-08-13 um 11 28 17](https://github.com/user-attachments/assets/6a5d2faa-88af-42db-9514-a07b3eabb0fb)


#### dark theme v2
![Bildschirmfoto 2024-08-13 um 11 40 49](https://github.com/user-attachments/assets/50aec64e-6ca1-49b7-8bd0-b4e2dcc3cd93)


I hope this can be an useful addition to your already very beautiful theme :)
Please let me know any feedback ✌️ 